### PR TITLE
✨feat:사용자 로그아웃 기능 추가(refresh token black-list 처리)

### DIFF
--- a/src/main/java/com/picktartup/userservice/controller/AuthController.java
+++ b/src/main/java/com/picktartup/userservice/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.picktartup.userservice.controller;
+
+// jwt 인증이 필요한 API
+import com.picktartup.userservice.common.CommonResult;
+import com.picktartup.userservice.service.ResponseService;
+import com.picktartup.userservice.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "사용자 인증 API", description = "사용자 로그아웃과 관련된 API")
+@RestController
+@RequestMapping("/api/v1/users/auth")
+@RequiredArgsConstructor
+@CrossOrigin("*")
+public class AuthController {
+
+    private final UserService userService;
+    private final ResponseService responseService;
+
+    @Operation(summary = "로그아웃", description = "사용자의 로그아웃과 관련된 API")
+    @DeleteMapping("/logout")
+    public CommonResult logout(HttpServletRequest request) {
+        userService.logout(request);
+        return responseService.getSuccessfulResult();
+    }
+}

--- a/src/main/java/com/picktartup/userservice/controller/UserController.java
+++ b/src/main/java/com/picktartup/userservice/controller/UserController.java
@@ -34,16 +34,17 @@ public class UserController {
         return healthStatus.toString(); // 텍스트 형식으로 반환
     }
 
-    @Operation(summary = "사용자 회원가입")
+    @Operation(summary = "사용자 회원가입과 관련된 API")
     @PostMapping("/register")
     public CommonResult userRegister(@RequestBody UserRequestDto userRequestDto){
         return userService.register(userRequestDto);
     }
 
-    @Operation(summary = "사용자 로그인")
+    @Operation(summary = "사용자 로그인과 관련된 API")
     @PostMapping("/login")
     public CommonResult userLogin(@RequestBody UserLoginRequest loginRequest){
         JWTAuthResponse token = userService.login(loginRequest);
         return responseService.getSingleResult(token);
     }
+
 }

--- a/src/main/java/com/picktartup/userservice/exception/BusinessLogicException.java
+++ b/src/main/java/com/picktartup/userservice/exception/BusinessLogicException.java
@@ -1,0 +1,15 @@
+package com.picktartup.userservice.exception;
+
+public class BusinessLogicException extends RuntimeException {
+
+    private final ExceptionList exceptionList;
+
+    public BusinessLogicException(ExceptionList exceptionList) {
+        super(exceptionList.getMessage());
+        this.exceptionList = exceptionList;
+    }
+
+    public ExceptionList getExceptionList() {
+        return exceptionList;
+    }
+}

--- a/src/main/java/com/picktartup/userservice/service/Service.java
+++ b/src/main/java/com/picktartup/userservice/service/Service.java
@@ -1,4 +1,0 @@
-package com.picktartup.userservice.service;
-
-public interface Service {
-}

--- a/src/main/java/com/picktartup/userservice/service/ServiceImpl.java
+++ b/src/main/java/com/picktartup/userservice/service/ServiceImpl.java
@@ -1,4 +1,0 @@
-package com.picktartup.userservice.service;
-
-public class ServiceImpl {
-}

--- a/src/main/java/com/picktartup/userservice/service/UserService.java
+++ b/src/main/java/com/picktartup/userservice/service/UserService.java
@@ -4,6 +4,7 @@ import com.picktartup.userservice.common.CommonResult;
 import com.picktartup.userservice.dto.request.UserLoginRequest;
 import com.picktartup.userservice.dto.request.UserRequestDto;
 import com.picktartup.userservice.dto.response.JWTAuthResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserService {
 
@@ -11,4 +12,5 @@ public interface UserService {
 
     JWTAuthResponse login(UserLoginRequest loginRequest);
 
+    void logout(HttpServletRequest request);
 }


### PR DESCRIPTION
### 👀 관련 이슈
- #5 

### ✨ 작업한 내용
로그아웃 기능이 수행된다.

### 🌀 PR Point
**보안 상 로그아웃 시 리프레시 토큰 검증(블랙리스트) 기능을 추가하였습니다.**
JwtTokenProvider
<img width="643" alt="스크린샷 2024-11-07 오전 11 00 26" src="https://github.com/user-attachments/assets/532cca79-36f7-4fb0-89d5-e4f3bb47ee72">

토큰은 발급하면 서버에서 제어권을 잃습니다. 즉, 토큰을 서버에서 삭제해도 클라이언트에서 탈취하면 유효시간이 남아있으면 유효한 토큰을 가지고 사용자 인증이 가능하기 때문에 보안상 문제를 일으킵니다. 따라서 로그아웃 하면 토큰을 서버쪽 Redis에서 삭제하는 것이 아니라 토큰을 무효화하기 위해서 토큰의 남아있는 시간동안 블랙리스트 처리했습니다. 무효화된(로그아웃된) 토큰으로 인증을 시도하면 블랙리스트에 포함되어 있는지 확인하고, 블랙리스트에 포함되어 있으면 인증이 되지 않도록 처리했습니다. 

즉, 로그아웃을 하면 토큰은 실제로 살아 있지만 블랙 리스트 처리를 했기 때문에 살아있는 토큰을 가지고 인증을 시도해도 서버쪽에서 정상 인증을 반환하지 않습니다. 따라서 서버쪽에서 민감한 사용자 정보를 반환하지 않습니다. 


### 📷 스크린샷 또는 GIF
| 기능                                    | 스크린샷                                                                                                                                         |
|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
| 요청(로그아웃 시 헤더에 토큰 필요)      | <img width="863" alt="image" src="https://github.com/user-attachments/assets/f8e649b8-1f1d-438e-886e-2e4625c04e42">                               |
| 응답                                    | <img width="620" alt="image" src="https://github.com/user-attachments/assets/0c06f19f-7d67-4614-94c5-43ff5313b0b0">                               |

