### PR TITLE
👷cicd: security 에 /actuator 헬스체크 경로 추가 및 kubectl 설정 변경

### DIFF
--- a/src/main/java/com/picktartup/userservice/config/SecurityConfig.java
+++ b/src/main/java/com/picktartup/userservice/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/api/v1/users/public/**",
+            "/actuator/**",
             "/",
             "/error"
     };


### PR DESCRIPTION
### 👀 관련 이슈
- #11 
- #14  

### ✨ 작업한 내용

1. **Security 설정 업데이트**  
   - `/actuator/health` 경로를 Security 설정에 추가하여 헬스체크 경로에 대한 접근을 허용

2. **Probe 설정 재검토**  
   - readinessProbe, livenessProbe, startupProbe의 설정 값(`initialDelaySeconds`, `failureThreshold`, `periodSeconds`)을 조정하여 충분한 초기화 시간이 제공되도록 수정.
   - Pod 내부에서 `8080` 포트의 `/actuator/health` 경로가 정상적으로 응답하는지 테스트 진행

#### 확인 과정

- **이슈 파악**:  
  Pod가 정상적으로 올라오는데 **63초**가 소요되는 것을 확인
  <img width="654" alt="Probe 설정 확인" src="https://github.com/user-attachments/assets/c249b80a-82fc-44d3-8952-0366464f424f">

- **기존 설정 문제점**:  
  readinessProbe와 startupProbe의 `initialDelaySeconds` 값이 **40초**로 설정되어 있어, 애플리케이션 초기화 시간(63초)을 충족하지 못하는 상태

#### 수정 내용

- **Probe 값 조정**:  
  `initialDelaySeconds` 값을 **120초**로 늘려 애플리케이션 초기화 시간을 충분히 확보
  <img width="495" alt="수정된 Probe 설정" src="https://github.com/user-attachments/assets/957ed449-1977-4810-822f-99b82b315433">

- **수정 결과**:  
  Pod가 초기화 시간에 맞춰 readinessProbe 및 startupProbe를 정상적으로 통과하며, `connection refused` 에러가 해결됨
  <img width="1437" alt="수정 후 Pod 정상 상태 확인" src="https://github.com/user-attachments/assets/afad403f-561d-41c3-bb90-f77b6b0bd8f1">



### 🌀 PR Point
actuator/health 로 확인해서 /actuatctor/** 경로를 모두 허용해주었습니다.

### 🍰 참고사항
- SecurityConfig 설정 파일 white_list 에 /actuactor/** 을 추가하고 기본 헬스체크 경로를 인증없이 할 수 있도록 수정하였습니다.
