### PR TITLE
🐛fix: acutator health_check 경로 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,16 +16,6 @@ spring:
     baseline-on-migrate: true
     locations: classpath:db/migration
     validate-on-migrate: true
-  management:
-    endpoints:
-      web:
-        exposure:
-          include: health # health 엔드포인트를 노출
-    health:
-      livenessstate:
-        enabled: true    # Liveness 상태를 활성화
-      readinessstate:
-        enabled: true    # Readiness 상태를 활성화
   data:
     redis:
       host: ${REDIS_HOST}
@@ -37,6 +27,29 @@ spring:
         max-active: 8
         min-idle: 2
         max-wait: 1000ms
+
+management:
+  endpoint:
+    health:
+      enabled: true
+      show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: "*"
+        liveness:
+          include: "*"
+  endpoints:
+    web:
+      exposure:
+        include: "health"
+      base-path: "/actuator"
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
### 👀 관련 이슈
- #14 

### ✨ 작업한 내용

1. Actuator Base Path 설정 추가
Spring Boot Actuator의 기본 경로를 /actuator로 설정하기 위해 management.endpoints.web.base-path 값을 추가

2. 헬스체크 경로 노출 설정
management.endpoints.web.exposure.include 설정으로 /actuator/health를 외부에 노출.


#### 확인 과정

- **이슈 파악**:  
파드도 정상적으로 running이고 로그 상 에러가 없지만 접속이 되지 않는 상태
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/6b784714-50fa-4c4c-94c5-fa3fb7dc24a9">

#### 수정 내용

application.yml 수정:
<img width="357" alt="스크린샷 2024-11-25 오후 5 10 17" src="https://github.com/user-attachments/assets/5047f230-8afd-42c7-9225-d8f265f3c9b2">


### 🌀 PR Point
헬스체크 노출 경로를 명확히 하여 Kubernetes 프로브 설정과 연동 가능하도록 구성
readinessProbe, livenessProbe, startupProbe에서 /actuator/health 경로 사용

