### PR TITLE
feat: 리프레시 토큰으로 토큰 재발급 로직

### DIFF
--- a/src/main/java/com/picktartup/userservice/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/picktartup/userservice/config/jwt/JwtTokenProvider.java
@@ -145,11 +145,11 @@ public class JwtTokenProvider {
 
     // Request Header에 Refresh Token 정보를 추출하는 메서드
     public String resolveRefreshToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Refresh");
-        if (StringUtils.hasText(bearerToken)) {
-            return bearerToken;
+        String bearerToken = request.getHeader("RefreshToken");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
         }
-        return null;
+        return bearerToken;
     }
 
     // 토큰의 유효성 검증

--- a/src/main/java/com/picktartup/userservice/controller/AuthController.java
+++ b/src/main/java/com/picktartup/userservice/controller/AuthController.java
@@ -12,7 +12,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Mono;
 
 @Tag(name = "사용자 인증 API", description = "사용자 로그아웃과 관련된 API")
 @Slf4j
@@ -52,4 +51,5 @@ public class AuthController {
         UserDto.UserValidationResponse validation = userService.validateUser(userId);
         return responseService.getSingleResult(validation);
     }
+
 }

--- a/src/main/java/com/picktartup/userservice/controller/AuthController.java
+++ b/src/main/java/com/picktartup/userservice/controller/AuthController.java
@@ -40,12 +40,16 @@ public class AuthController {
     public SingleResult<UserDto.UserInfoResponse> getUserById(@PathVariable Long userId) {
         try {
             UserDto.UserInfoResponse response = userService.getUserById(userId);
-            log.info("Successfully fetched user and wallet info for userId: {}", userId);
             return responseService.getSingleResult(response);
         } catch (Exception e) {
-            log.error("Error fetching user info for userId {}: {}", userId, e.getMessage());
             throw e;
         }
     }
 
+    // 사용자 존재 여부 확인용 간단 API
+    @GetMapping("/{userId}/validation")
+    public SingleResult<UserDto.UserValidationResponse> validateUser(@PathVariable Long userId) {
+        UserDto.UserValidationResponse validation = userService.validateUser(userId);
+        return responseService.getSingleResult(validation);
+    }
 }

--- a/src/main/java/com/picktartup/userservice/controller/UserController.java
+++ b/src/main/java/com/picktartup/userservice/controller/UserController.java
@@ -8,6 +8,8 @@ import com.picktartup.userservice.service.ResponseService;
 import com.picktartup.userservice.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,6 +45,15 @@ public class UserController {
     public CommonResult userLogin(@RequestBody UserDto.SignInRequest loginRequest){
         UserDto.AuthResponse token = userService.login(loginRequest);
         return responseService.getSingleResult(token);
+    }
+
+    @Operation(summary = "토큰 재발급", description = "리프레쉬 토큰으로 액세스 토큰을 재발급 하는 API")
+    @PatchMapping("/reissue")
+    public CommonResult reissue(HttpServletRequest request,
+                                HttpServletResponse response) {
+
+        UserDto.AuthResponse newAccessToken = userService.reissueAccessToken(request);
+        return responseService.getSingleResult(newAccessToken);
     }
 
 }

--- a/src/main/java/com/picktartup/userservice/dto/UserDto.java
+++ b/src/main/java/com/picktartup/userservice/dto/UserDto.java
@@ -79,4 +79,14 @@ public class UserDto {
         private BigDecimal walletBalance;
         private String walletStatus;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserValidationResponse {
+        private Long id;
+        private String username;
+        private String status;  // ACTIVE, INACTIVE 등 사용자 상태
+    }
 }

--- a/src/main/java/com/picktartup/userservice/entity/UserEntity.java
+++ b/src/main/java/com/picktartup/userservice/entity/UserEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Getter
 @Setter
@@ -37,5 +38,9 @@ public class UserEntity {
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
+
+    public static UserEntity of(Optional<UserEntity> userEntity) {
+        return userEntity.orElseThrow(() -> new RuntimeException("User not found"));
+    }
 
 }

--- a/src/main/java/com/picktartup/userservice/exception/ExceptionList.java
+++ b/src/main/java/com/picktartup/userservice/exception/ExceptionList.java
@@ -30,11 +30,13 @@ public enum ExceptionList {
     TOKEN_EXPIRED(401, "토큰이 만료되었습니다."),
     TOKEN_INVALID(401, "유효하지 않은 토큰입니다."),
     AUTHENTICATION_FAILED(401, "인증에 실패했습니다."),
+    TOKEN_IS_NOT_SAME(401, "토큰이 일치하지 않습니다."),
+    HEADER_REFRESH_TOKEN_NOT_EXISTS(401, "Refresh Token이 존재하지 않습니다."),
 
     // 데이터베이스 관련 예외
     DATABASE_ERROR(500, "데이터베이스 오류가 발생했습니다."),
     DUPLICATE_ENTRY(409, "중복된 데이터가 존재합니다."),
-    DATA_NOT_FOUND(404, "데이터를 찾을 수 없습니다.");
+    DATA_NOT_FOUND(404, "데이터를 찾을 수 없습d니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/picktartup/userservice/service/UserService.java
+++ b/src/main/java/com/picktartup/userservice/service/UserService.java
@@ -15,4 +15,6 @@ public interface UserService {
     UserDto.UserInfoResponse getUserById(Long userId);
 
     UserDto.UserValidationResponse validateUser(Long userId);
+
+    UserDto.AuthResponse reissueAccessToken(HttpServletRequest request);
 }

--- a/src/main/java/com/picktartup/userservice/service/UserService.java
+++ b/src/main/java/com/picktartup/userservice/service/UserService.java
@@ -13,4 +13,6 @@ public interface UserService {
     void logout(HttpServletRequest request);
 
     UserDto.UserInfoResponse getUserById(Long userId);
+
+    UserDto.UserValidationResponse validateUser(Long userId);
 }

--- a/src/main/java/com/picktartup/userservice/service/UserServiceImpl.java
+++ b/src/main/java/com/picktartup/userservice/service/UserServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -104,6 +105,7 @@ public class UserServiceImpl implements UserService{
         }
     }
 
+    @Override
     public UserDto.UserInfoResponse getUserById(Long userId) {
         ModelMapper modelMapper = new ModelMapper();
         // 1. User 정보 조회
@@ -139,4 +141,29 @@ public class UserServiceImpl implements UserService{
                 .status(user.getIsActivated() ? "ACTIVE" : "INACTIVE")  // Boolean 값을 상태 문자열로 변환
                 .build();
     }
+
+    @Override
+    public UserDto.AuthResponse reissueAccessToken(HttpServletRequest request) {
+        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+        this.verifiedRefreshToken(refreshToken);
+
+        String email = jwtTokenProvider.getEmail(refreshToken);
+        String redisRefreshToken = redisServiceImpl.getValues(email);
+
+        if (redisServiceImpl.checkExistsValue(redisRefreshToken) && refreshToken.equals(redisRefreshToken)) {
+            Optional<UserEntity> findUser = userRepository.findByEmail(email);
+            UserEntity userEntity = UserEntity.of(findUser);
+            UserDto.AuthResponse tokenDto = jwtTokenProvider.generateToken(jwtTokenProvider.getAuthentication(refreshToken), userEntity.getUserId(), userEntity.getUsername());
+            return tokenDto;
+        } else throw new BusinessLogicException(ExceptionList.TOKEN_IS_NOT_SAME);
+
+    }
+
+    private void verifiedRefreshToken(String refreshToken) {
+        if (refreshToken == null) {
+            throw new BusinessLogicException(ExceptionList.HEADER_REFRESH_TOKEN_NOT_EXISTS);
+        }
+    }
+
+
 }

--- a/src/main/java/com/picktartup/userservice/service/UserServiceImpl.java
+++ b/src/main/java/com/picktartup/userservice/service/UserServiceImpl.java
@@ -125,4 +125,18 @@ public class UserServiceImpl implements UserService{
 
         return userResponse;
     }
+
+    @Override
+    public UserDto.UserValidationResponse validateUser(Long userId) {
+        // 1. User 정보 조회
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionList.USER_NOT_FOUND));
+
+        // 2. UserValidationResponse 생성 및 반환
+        return UserDto.UserValidationResponse.builder()
+                .id(user.getUserId())
+                .username(user.getUsername())
+                .status(user.getIsActivated() ? "ACTIVE" : "INACTIVE")  // Boolean 값을 상태 문자열로 변환
+                .build();
+    }
 }


### PR DESCRIPTION
### 👀 관련 이슈  
- #5 

### ✨ 작업한 내용  
1. **리프레시 토큰을 통한 액세스 토큰 재발급 로직 추가**  
   - 기존 인증 로직에 리프레시 토큰 기반의 재발급 기능 구현
   - 유효성 검사 및 토큰 재발급 절차를 추가하여 인증 흐름 개선

### 🌀 PR Point  
- 토큰 만료 시 예외 처리 및 재발급 흐름의 테스트 시나리오 확인
- 기존 인증 로직과의 충돌 여부 점검

### 🍰 참고사항  
- 보안성 강화를 위해 토큰 블랙리스트 관리 기능 추가되어 있음

### 📷 스크린샷 또는 GIF  
<img width="890" alt="image" src="https://github.com/user-attachments/assets/d1e2235c-b24d-48c0-8bd9-9e6fbb8c802d">