### PR TITLE
🐛fix: userid 로 조회 시 응답값에 email 필드 추가

### DIFF
--- a/src/main/java/com/picktartup/userservice/dto/UserDto.java
+++ b/src/main/java/com/picktartup/userservice/dto/UserDto.java
@@ -87,6 +87,7 @@ public class UserDto {
     public static class UserValidationResponse {
         private Long id;
         private String username;
+        private String email;
         private String status;  // ACTIVE, INACTIVE 등 사용자 상태
     }
 }

--- a/src/main/java/com/picktartup/userservice/service/UserServiceImpl.java
+++ b/src/main/java/com/picktartup/userservice/service/UserServiceImpl.java
@@ -137,6 +137,7 @@ public class UserServiceImpl implements UserService{
         // 2. UserValidationResponse 생성 및 반환
         return UserDto.UserValidationResponse.builder()
                 .id(user.getUserId())
+                .email(user.getEmail())
                 .username(user.getUsername())
                 .status(user.getIsActivated() ? "ACTIVE" : "INACTIVE")  // Boolean 값을 상태 문자열로 변환
                 .build();


### PR DESCRIPTION
### 👀 관련 이슈
- #16 

### ✨ 작업한 내용
**userId로 조회 시 응답값에 EMAIL 필드 추가**
`http://localhost:8080/api/v1/users/auth/{userId}/validation`

- 이메일 전송 시 스타트업 이메일 정보가 필요함
- campaignId로 startup service 에서 userid 조회 -> userId 로 user service 에서 email 조회

### 🌀 PR Point
userservice 에서는 간단하게 반환값에 EMAIL 만 추가했습니다.

### 🍰 참고사항
리팩토링, 클래스 명 맞춰야 할 게 많습니다.
