### PR TITLE
🐛fix: 회원가입 후 지갑 생성 위한 userid 반환하도록 수정

### DIFF
--- a/src/main/java/com/picktartup/userservice/controller/UserController.java
+++ b/src/main/java/com/picktartup/userservice/controller/UserController.java
@@ -3,6 +3,7 @@ package com.picktartup.userservice.controller;
 //jwt 인증이 필요 없는 api
 
 import com.picktartup.userservice.common.CommonResult;
+import com.picktartup.userservice.common.SingleResult;
 import com.picktartup.userservice.dto.UserDto;
 import com.picktartup.userservice.service.ResponseService;
 import com.picktartup.userservice.service.UserService;
@@ -36,7 +37,7 @@ public class UserController {
 
     @Operation(summary = "사용자 회원가입과 관련된 API")
     @PostMapping("/register")
-    public CommonResult userRegister(@RequestBody UserDto.SignUpRequest signUpRequest){
+    public SingleResult<Long> userRegister(@RequestBody UserDto.SignUpRequest signUpRequest){
         return userService.register(signUpRequest);
     }
 

--- a/src/main/java/com/picktartup/userservice/service/ResponseService.java
+++ b/src/main/java/com/picktartup/userservice/service/ResponseService.java
@@ -29,6 +29,15 @@ public class ResponseService {
         return result;
     }
 
+    public <T> SingleResult<T> getSingleResultwithMessage(T data, String message) {
+        SingleResult<T> result = new SingleResult<>();
+        result.setSuccess(true);
+        result.setCode(200);
+        result.setMessage(message);
+        result.setData(data);
+        return result;
+    }
+
     // 단일건 결과 처리 메서드 - 비동기
     public <T> Mono<SingleResult<T>> getMonoSingleResult(Mono<T> data) {
         return data.map(result -> {

--- a/src/main/java/com/picktartup/userservice/service/UserService.java
+++ b/src/main/java/com/picktartup/userservice/service/UserService.java
@@ -1,12 +1,12 @@
 package com.picktartup.userservice.service;
 
-import com.picktartup.userservice.common.CommonResult;
+import com.picktartup.userservice.common.SingleResult;
 import com.picktartup.userservice.dto.UserDto;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserService {
 
-    CommonResult register(UserDto.SignUpRequest signUpRequest);
+    SingleResult<Long> register(UserDto.SignUpRequest signUpRequest);
 
     UserDto.AuthResponse login(UserDto.SignInRequest loginRequest);
 


### PR DESCRIPTION
### 👀 관련 이슈
#5 

### ✨ 작업한 내용
회원가입 후 지갑 생성 위한 userid 반환하도록 수정

### 🌀 PR Point
x

### 🍰 참고사항
회원가입 시 지갑 생성도 함께 진행하기 때문에 회원가입 후 userid를 반환하여 그 userid로 지갑을 생성해야 합니다. 따라서 회원가입 후 userid 를 반환하도록 수정했습니다.

### 📷 스크린샷 또는 GIF
<img width="890" alt="image" src="https://github.com/user-attachments/assets/1a60835d-544e-427c-b1d0-bdfc787dfd5a">