### PR TITLE
🐛fix: user 간단 조회 시 토큰 인증 제외

### DIFF
--- a/src/main/java/com/picktartup/userservice/controller/AuthController.java
+++ b/src/main/java/com/picktartup/userservice/controller/AuthController.java
@@ -45,11 +45,4 @@ public class AuthController {
         }
     }
 
-    // 사용자 존재 여부 확인용 간단 API
-    @GetMapping("/{userId}/validation")
-    public SingleResult<UserDto.UserValidationResponse> validateUser(@PathVariable Long userId) {
-        UserDto.UserValidationResponse validation = userService.validateUser(userId);
-        return responseService.getSingleResult(validation);
-    }
-
 }

--- a/src/main/java/com/picktartup/userservice/controller/UserController.java
+++ b/src/main/java/com/picktartup/userservice/controller/UserController.java
@@ -57,4 +57,11 @@ public class UserController {
         return responseService.getSingleResult(newAccessToken);
     }
 
+    // 사용자 존재 여부 확인용 간단 API
+    @GetMapping("/{userId}/validation")
+    public SingleResult<UserDto.UserValidationResponse> validateUser(@PathVariable Long userId) {
+        UserDto.UserValidationResponse validation = userService.validateUser(userId);
+        return responseService.getSingleResult(validation);
+    }
+
 }


### PR DESCRIPTION
### 👀 관련 이슈
- #5 
- #16 

### ✨ 작업한 내용
user 간단 조회 시 토큰 인증 제외 
`http://192.168.0.143:32450/user/api/v1/users/auth/13/validation`

### 🌀 PR Point
x

### 🍰 참고사항
지갑 생성 시 사용자가 존재하는지 확인하는 로직이 포함되어 있는데 검증을 위해서 userservice 에서 조회를 하는데 이때 로그인이 되지 않은 상태이기 때문에 토큰 인증이 불필요하여 제거하였습니다.

