### PR TITLE
✨feat: 관리자 페이지 리다이렉트 위한 로그인 성공 시 권한 반환

### DIFF
--- a/src/main/java/com/picktartup/userservice/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/picktartup/userservice/config/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.picktartup.userservice.config.jwt;
 
 import com.picktartup.userservice.dto.UserDto;
+import com.picktartup.userservice.entity.Role;
 import com.picktartup.userservice.service.MyUserDetailsService;
 import com.picktartup.userservice.service.RedisService;
 import io.jsonwebtoken.*;
@@ -47,7 +48,7 @@ public class JwtTokenProvider {
     }
 
     // JWT 토큰 생성하는 메소드
-    public UserDto.AuthResponse generateToken(Authentication authentication, Long userId, String name) {
+    public UserDto.AuthResponse generateToken(Authentication authentication, Long userId, String name, Role role) {
         String email = authentication.getName();
 
         Claims claims = Jwts.claims().setSubject(email);
@@ -74,6 +75,7 @@ public class JwtTokenProvider {
 
         redisService.setValues(email, refreshToken, Duration.ofMillis(REFRESH_TOKEN_VALID_TIME));
         return UserDto.AuthResponse.builder()
+                .role(role)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .tokenType(BEARER)

--- a/src/main/java/com/picktartup/userservice/dto/UserDto.java
+++ b/src/main/java/com/picktartup/userservice/dto/UserDto.java
@@ -1,6 +1,9 @@
 package com.picktartup.userservice.dto;
 
+import com.picktartup.userservice.entity.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -56,6 +59,7 @@ public class UserDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AuthResponse {
+        private Role role;
         private String tokenType;
         private String accessToken;
         private String refreshToken;

--- a/src/main/java/com/picktartup/userservice/service/MyUserDetailsService.java
+++ b/src/main/java/com/picktartup/userservice/service/MyUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.picktartup.userservice.service;
 
+import com.picktartup.userservice.entity.Role;
 import com.picktartup.userservice.entity.UserEntity;
 import com.picktartup.userservice.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,16 @@ public class MyUserDetailsService implements UserDetailsService {
         Optional<UserEntity> userOptional = userRepository.findByEmail(email);
         if (userOptional.isPresent()) {
             return userOptional.get().getUsername(); //사용자 이름
+        }
+
+        throw new UsernameNotFoundException("해당하는 사용자가 없습니다: " + email);
+
+    }
+
+    public Role findRoleByEmail(String email) {
+        Optional<UserEntity> userOptional = userRepository.findByEmail(email);
+        if (userOptional.isPresent()) {
+            return userOptional.get().getRole();
         }
 
         throw new UsernameNotFoundException("해당하는 사용자가 없습니다: " + email);

--- a/src/main/java/com/picktartup/userservice/service/UserServiceImpl.java
+++ b/src/main/java/com/picktartup/userservice/service/UserServiceImpl.java
@@ -74,7 +74,9 @@ public class UserServiceImpl implements UserService{
         SecurityContextHolder.getContext().setAuthentication(authentication);
         Long userId = myUserDetailsService.findUserIdByEmail(loginRequest.getEmail()); //1
         String name = myUserDetailsService.findNameByEmail(loginRequest.getEmail()); //fisa@gmail.com
-        UserDto.AuthResponse token = jwtTokenProvider.generateToken(authentication, userId, name);
+        Role role = myUserDetailsService.findRoleByEmail(loginRequest.getEmail()); //admin, user
+
+        UserDto.AuthResponse token = jwtTokenProvider.generateToken(authentication, userId, name, role);
         return token;
 
     }
@@ -156,7 +158,7 @@ public class UserServiceImpl implements UserService{
         if (redisServiceImpl.checkExistsValue(redisRefreshToken) && refreshToken.equals(redisRefreshToken)) {
             Optional<UserEntity> findUser = userRepository.findByEmail(email);
             UserEntity userEntity = UserEntity.of(findUser);
-            UserDto.AuthResponse tokenDto = jwtTokenProvider.generateToken(jwtTokenProvider.getAuthentication(refreshToken), userEntity.getUserId(), userEntity.getUsername());
+            UserDto.AuthResponse tokenDto = jwtTokenProvider.generateToken(jwtTokenProvider.getAuthentication(refreshToken), userEntity.getUserId(), userEntity.getUsername(), userEntity.getRole());
             return tokenDto;
         } else throw new BusinessLogicException(ExceptionList.TOKEN_IS_NOT_SAME);
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,7 +24,7 @@ spring:
 
   data:
     redis:
-      host: ${REDIS_HOST}
+      host: localhost
       port: ${REDIS_PORT}
       connect-timeout: 3000ms
       client-name: my-redis-app


### PR DESCRIPTION
### 👀 관련 이슈
- #2 

### ✨ 작업한 내용
- 로그인 성공 시 사용자 권한 정보를 응답에 포함하도록 수정
- 관리자 페이지로 리다이렉트가 가능하도록 권한 정보 반환 로직 추가

### 🌀 PR Point
- 권한 반환 로직이 기존 로그인 응답 흐름에 적절히 통합되었는지 확인

### 🍰 참고사항
- 클라이언트 측에서 권한 정보를 활용해 리다이렉트 로직 구현 예정
- 반환되는 권한 정보가 불필요하게 노출되지 않도록 보안 점검 필요

### 📷 스크린샷 또는 GIF
<img width="1282" alt="스크린샷 2024-12-05 오전 9 36 59" src="https://github.com/user-attachments/assets/1a2cd39c-3c3a-43fb-b7b0-3bf435ef256d">

