### PR TITLE
👷cicd: resttemplate 통신 시 ssl 인증서 허용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql:10.6.0'
 
+    // Apache HTTP Client 5
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
+    implementation 'org.apache.httpcomponents.core5:httpcore5:5.2.1'
 
     // Spring AOP
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/src/main/java/com/picktartup/userservice/webclient/WalletServiceClient.java
+++ b/src/main/java/com/picktartup/userservice/webclient/WalletServiceClient.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+
 import java.math.BigDecimal;
 
 @Slf4j
@@ -88,4 +89,5 @@ public class WalletServiceClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         return headers;
     }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,4 +38,4 @@ resilience4j.timelimiter:
 
 service:
   wallet:
-    url: http://192.168.0.142:32450/wallet
+    url: https://192.168.0.141:31158/wallet


### PR DESCRIPTION
### 👀 관련 이슈
- #16 
- #25 
- 
### ✨ 작업한 내용
온프레미스 https 적용함에 따라서 하이브리드 환경에서 통신 시 인증서 오류가 났습니다.
```
org.springframework.web.reactive.function.client.WebClientRequestException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
	at org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction.lambda$wrapException$9(ExchangeFunctions.java:136) ~[spring-webflux-6.1.14.jar:6.1.14]
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Error has been observed at the following site(s):
	*__checkpoint ⇢ Request to GET https://192.168.0.141:31158/wallet/api/v1/wallets/user/67 [DefaultWebClient]
```


온프레미스 https 적용됨에 따라 resttemplate 통신 시 ssl 설정 허용해주었습니다.

### 🌀 PR Point
webclient 빈 등록시 ssl 설정 접속을 허용해 주었습니다.
```@Bean
    public RestTemplate walletServiceRestTemplate() {
        try {
            // SSLContext 설정
            SSLContext sslContext = SSLContextBuilder.create()
                    .loadTrustMaterial(null, new TrustAllStrategy())
                    .build();

            // SSL Connection Factory 생성
            SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(
                    sslContext,
                    NoopHostnameVerifier.INSTANCE
            );

            // CloseableHttpClient 생성
            CloseableHttpClient httpClient = HttpClients.custom()
                    .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
                            .setSSLSocketFactory(sslFactory)
                            .build())
                    .build();

            // HttpComponentsClientHttpRequestFactory 생성
            HttpComponentsClientHttpRequestFactory requestFactory =
                    new HttpComponentsClientHttpRequestFactory();
            requestFactory.setHttpClient(httpClient);

            return new RestTemplate(requestFactory);
        } catch (Exception e) {
            log.error("Error creating RestTemplate with SSL configuration: {}", e.getMessage());
            throw new RuntimeException(e);
        }
    }
```


### 🍰 참고사항
온프레미스 쪽 통신만 ssl 을 허용해주면 됩니다.

### 사진
<img width="856" alt="image" src="https://github.com/user-attachments/assets/aae6da7e-540f-4aaa-bbed-3d6c918a7335">


